### PR TITLE
Force dark color scheme

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,7 +1,6 @@
 import { View, Text, ScrollView, Alert } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { EraserIcon, MoonIcon, UploadIcon } from "lucide-react-native";
-import { useColorScheme } from "@/lib/hooks/useColorScheme";
+import { EraserIcon, UploadIcon } from "lucide-react-native";
 import { seedWorkSessions, clearWorkSessions } from "@/lib/seedData";
 import SettingsGroup from "@/components/settings/SettingsGroup";
 import SettingsItem from "@/components/settings/SettingsItem";
@@ -11,11 +10,9 @@ const appVariant = Constants.expoConfig?.extra?.APP_VARIANT;
 const isProduction = appVariant !== "development" && appVariant !== "preview";
 
 export default function SettingsScreen() {
-  const { isDarkColorScheme, setColorScheme } = useColorScheme();
-
   const seedData = async () => {
     try {
-      await seedWorkSessions();
+      seedWorkSessions();
       Alert.alert("Success", "Dummy data seeded");
     } catch (e) {
       console.error(e);
@@ -25,7 +22,7 @@ export default function SettingsScreen() {
 
   const clearData = async () => {
     try {
-      await clearWorkSessions();
+      clearWorkSessions();
       Alert.alert("Success", "Data cleared");
     } catch (e) {
       console.error(e);
@@ -44,18 +41,6 @@ export default function SettingsScreen() {
         </View>
 
         <View className="gap-4">
-          <SettingsGroup>
-            <SettingsItem
-              Icon={MoonIcon}
-              text="Dark Mode"
-              onPress={() =>
-                setColorScheme(isDarkColorScheme ? "light" : "dark")
-              }
-              isSwitch={true}
-              initialIsChecked={isDarkColorScheme}
-            />
-          </SettingsGroup>
-
           {!isProduction && (
             <SettingsGroup>
               <SettingsItem

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,22 +1,12 @@
 import "@/global.css";
 
 import { NAV_THEME } from "@/lib/constants/colors";
-import { useColorScheme } from "@/lib/hooks/useColorScheme";
-import {
-  DarkTheme,
-  DefaultTheme,
-  Theme,
-  ThemeProvider,
-} from "@react-navigation/native";
+import { DarkTheme, Theme, ThemeProvider } from "@react-navigation/native";
 
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useLayoutEffect, useRef, useState } from "react";
 
-const LIGHT_THEME: Theme = {
-  ...DefaultTheme,
-  colors: NAV_THEME.light,
-};
 const DARK_THEME: Theme = {
   ...DarkTheme,
   colors: NAV_THEME.dark,
@@ -26,7 +16,6 @@ export { ErrorBoundary } from "expo-router";
 
 export default function RootLayout() {
   const hasMounted = useRef(false);
-  const { isDarkColorScheme } = useColorScheme();
   const [isColorSchemeLoaded, setIsColorSchemeLoaded] = useState(false);
 
   useLayoutEffect(() => {
@@ -41,8 +30,8 @@ export default function RootLayout() {
   }
 
   return (
-    <ThemeProvider value={isDarkColorScheme ? DARK_THEME : LIGHT_THEME}>
-      <StatusBar style={isDarkColorScheme ? "light" : "dark"} />
+    <ThemeProvider value={DARK_THEME}>
+      <StatusBar style="light" />
       <Stack
         screenOptions={{
           headerShown: false,

--- a/lib/hooks/useColorScheme.tsx
+++ b/lib/hooks/useColorScheme.tsx
@@ -1,12 +1,16 @@
 import { useColorScheme as useNativewindColorScheme } from "nativewind";
+import { useEffect } from "react";
 
 export function useColorScheme() {
-  const { colorScheme, setColorScheme, toggleColorScheme } =
-    useNativewindColorScheme();
+  const { setColorScheme } = useNativewindColorScheme();
+  useEffect(() => {
+    setColorScheme("dark");
+  }, [setColorScheme]);
+
   return {
-    colorScheme: colorScheme ?? "dark",
-    isDarkColorScheme: colorScheme === "dark",
-    setColorScheme,
-    toggleColorScheme,
+    colorScheme: "dark" as const,
+    isDarkColorScheme: true,
+    setColorScheme: (_: "light" | "dark") => {},
+    toggleColorScheme: () => {},
   };
 }


### PR DESCRIPTION
This pull request removes support for toggling between light and dark themes in the app, simplifying the color scheme logic to always use the dark theme. It also removes unused code and updates related functions accordingly.

### Removal of Theme Toggling:
* Removed the `MoonIcon` and the "Dark Mode" toggle from the settings screen, along with related hooks and state management (`useColorScheme`) in `app/(tabs)/settings.tsx`. [[1]](diffhunk://#diff-508a25a6a97ebb3c75b31f13dcaf0fe720319c0f23b54258fd151a39b43f7938L3-R3) [[2]](diffhunk://#diff-508a25a6a97ebb3c75b31f13dcaf0fe720319c0f23b54258fd151a39b43f7938L47-L58)
* Simplified the `useColorScheme` hook to always return a dark theme and removed unused methods (`setColorScheme` and `toggleColorScheme`) in `lib/hooks/useColorScheme.tsx`.

### Simplification of Theme Handling:
* Removed the light theme definition (`LIGHT_THEME`) and references to `useColorScheme` in `app/_layout.tsx`. The app now always uses the dark theme (`DARK_THEME`). [[1]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57L4-L19) [[2]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57L29) [[3]](diffhunk://#diff-a297596ca5a79abd3db7509592a07106f1c27c02ee55895a4dee8bcce9f7da57L44-R34)

### Miscellaneous Updates:
* Updated `seedData` and `clearData` functions in the settings screen to remove unnecessary `await` keywords, as the functions are synchronous. [[1]](diffhunk://#diff-508a25a6a97ebb3c75b31f13dcaf0fe720319c0f23b54258fd151a39b43f7938L14-R15) [[2]](diffhunk://#diff-508a25a6a97ebb3c75b31f13dcaf0fe720319c0f23b54258fd151a39b43f7938L28-R25)